### PR TITLE
Add operation validation for suspend and resume

### DIFF
--- a/suspend_or_resume_fabric_capacity.ps1
+++ b/suspend_or_resume_fabric_capacity.ps1
@@ -1,5 +1,6 @@
 Param(
     [string]$ResourceID, # e.g. "/subscriptions/12345678-1234-1234-1234-123a12b12d1c/resourceGroups/fabric-rg/providers/Microsoft.Fabric/capacities/myf2capacity"
+    [ValidateSet("suspend", "resume")]
     [string]$operation # "suspend" or "resume"
 )
 
@@ -7,25 +8,44 @@ Param(
 #$operation = "suspend" 
 #$operation = "resume"
 
-Connect-AzAccount -Identity
+$ErrorActionPreference = "Stop"
 
-$tokenObject = Get-AzAccessToken -ResourceUrl "https://management.azure.com/"
-$token = $tokenObject.Token
+try {
+    "Logging in to Azure..."
+    Connect-AzAccount -Identity
+}
+catch {
+    Write-Error -Message $_.Exception
+    throw $_.Exception
+}
 
 $azContext = Get-AzContext
 $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
 $profileClient = New-Object -TypeName Microsoft.Azure.Commands.ResourceManager.Common.RMProfileClient -ArgumentList ($azProfile)
 $tokenObject = $profileClient.AcquireAccessToken($azContext.Subscription.TenantId)
 $token = $tokenObject.AccessToken
-
-$url = "https://management.azure.com$ResourceID/$operation" + "?api-version=2022-07-01-preview"
-Write-Output $url
-
 $headers = @{
-    'Content-Type' = 'application/json'
+    'Content-Type'  = 'application/json'
     'Authorization' = "Bearer $token"
 }
 
-$response = Invoke-RestMethod -Uri $url -Method Post -Headers $headers
+$capacityUrl = "https://management.azure.com$ResourceID" + "?api-version=2023-11-01"
+$capacityResourceResponse = Invoke-RestMethod -Uri $capacityUrl -Method Get -Headers $headers
 
+if ($operation -eq "suspend" -and $capacityResourceResponse.properties.state -ne "Active") {
+    Write-Warning "Cannot suspend. Current state: $($capacityResourceResponse.properties.state)"
+    return
+}
+if ($operation -eq "resume" -and $capacityResourceResponse.properties.state -ne "Suspended") {
+    Write-Warning "Cannot resume. Current state: $($capacityResourceResponse.properties.state)"
+    return
+}
+
+$capacityOperationActionUrl = "https://management.azure.com$ResourceID/$operation" + "?api-version=2023-11-01"
+Write-Output $capacityOperationActionUrl
+
+$response = Invoke-RestMethod -Uri $capacityOperationActionUrl -Method Post -Headers $headers
 $response
+if ($response.status -ne "Succeeded") {    
+    throw "Capacity operation did not succeed."
+}


### PR DESCRIPTION
This pull request includes several improvements to the `suspend_or_resume_fabric_capacity.ps1` script, focusing on error handling, validation, and operational checks. The most important changes include adding validation for the operation parameter, enhancing error handling during Azure login, and ensuring the capacity state is appropriate before performing operations.

### Validation Improvements:
* Added `[ValidateSet("suspend", "resume")]` to the `$operation` parameter to ensure only valid operations are accepted.

### Error Handling Enhancements:
* Introduced a `try-catch` block to handle exceptions during Azure login and provide more informative error messages.
* Set `$ErrorActionPreference` to "Stop" to ensure the script stops on errors.

### Operational Checks:
* Added checks to verify the current state of the capacity before attempting to suspend or resume it, preventing invalid operations.

### API Version Update:
* Updated the API version in the URLs used for capacity operations to "2023-11-01".